### PR TITLE
修复了share paper link 别人打开时无法显示metadata

### DIFF
--- a/beta_frontend/nginx.conf
+++ b/beta_frontend/nginx.conf
@@ -64,7 +64,7 @@ server {
     }
 
     # Index services (port 8002) - find_similar, paper_content
-    location ~ ^/(find_similar|paper_content)/ {
+    location ~ ^/(find_similar|paper_content|get_metadata)/ {
         proxy_pass http://index_service;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/beta_frontend/nginx_mac.conf
+++ b/beta_frontend/nginx_mac.conf
@@ -72,7 +72,7 @@ http {
         }
 
         # Index services (port 8002) - find_similar, paper_content
-        location ~ ^/(find_similar|paper_content)/ {
+        location ~ ^/(find_similar|paper_content|get_metadata)/ {
             proxy_pass http://index_service;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;

--- a/beta_frontend/paper.html
+++ b/beta_frontend/paper.html
@@ -505,24 +505,34 @@
         }
 
         async function loadPaperInfo() {
+            // TODO: Fix this to not use sessionStorage in future
             // Try to get paper info from sessionStorage (passed from main page)
             const storedPaper = sessionStorage.getItem(`paper_${paperId}`);
             if (storedPaper) {
                 currentPaper = JSON.parse(storedPaper);
                 return;
             }
-
-            // If no stored paper info, create a minimal paper object
-            currentPaper = {
-                id: paperId,
-                title: 'Loading...',
-                authors: [],
-                abstract: '',
-                tags: [],
-                publishDate: '',
-                comments: '',
-                submittedDate: ''
-            };
+            response = await fetch(`/get_metadata/${encodeURIComponent(paperId)}`);
+            if (response.ok) {
+                const text = await response.text();
+                const metadata = JSON.parse(text);
+                currentPaper = {
+                    id: paperId,
+                    title: metadata.title || 'Unknown Title',
+                    authors: metadata.authors || [],
+                    publishDate: metadata.published_date || '',
+                    url: metadata.url || ''
+                };
+            } else {
+                // Fallback to minimal paper object
+                currentPaper = {
+                    id: paperId,
+                    title: 'Loading...',
+                    authors: [],
+                    publishDate: '',
+                    url: '',
+                };
+            }
         }
 
         async function loadPaperContent() {
@@ -533,6 +543,11 @@
                     // Recommended paper - load blog content
                     console.log(`Loading blog content for paper ${paperId}, user ${username}`);
                     response = await fetch(`/api/digests/blog_content/${encodeURIComponent(paperId)}/${encodeURIComponent(username)}`);
+                    // If blog not found, fall back to full paper
+                    if (!response.ok && response.status === 404) {
+                        console.log('Blog content not found, falling back to full paper');
+                        response = await fetch(`/paper_content/${encodeURIComponent(paperId)}`);
+                    }
                 } else {
                     // Searched paper - load full paper content
                     console.log(`Loading full paper content for paper ${paperId}`);


### PR DESCRIPTION
从favorites里 进入时候增加了一个fallback功能 
先尝试/blog_content/paper_id/user_name
404了之后从index_service直接读默认博客
/paper_content/paper_id